### PR TITLE
feat: add multiline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ## description
 
-rust cli for formatting yaml v1.2 that passes yamllint
-with default settings
+rust cli for formatting yaml v1.2 that passes yamllint with default settings
 
 ## build
 
@@ -18,18 +17,18 @@ Parses an input yaml and output v1.2 yaml file
 usage:
     ymlfxr bad.yaml > good.yaml
 
-USAGE:
-    ymlfxr [FLAGS] <input>
+Usage: ymlfxr [OPTIONS] <input>
 
-FLAGS:
-    -b, --bak        Create backup of file
-    -d, --debug      turn on debugging information
-    -h, --help       Prints help information
-    -i, --fix        Fix the file in place
-    -V, --version    Prints version information
+Arguments:
+  <input>  Sets the input file to use
 
-ARGS:
-    <input>    Sets the input file to use
+Options:
+  -i, --fix        Fix the file in place
+  -b, --bak        Create backup of file
+  -m, --multiline  Use multiline strings
+  -d, --debug      turn on debugging information
+  -h, --help       Print help
+  -V, --version    Print version
 ```
 
 ## examples
@@ -40,6 +39,8 @@ ymlfxr ./tests/bad.yaml > ./tests/good.yaml
 ymlfxr --fix ./tests/inplace.yaml
 
 ymlfxr --bak --fix ./tests/inplace_w_bak.yaml
+
+ymlfxr -m ./tests/bar.yaml
 ```
 
 ## test

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,12 @@ usage:
                 .long("bak")
                 .action(ArgAction::SetTrue),
         )
+        .arg(Arg::new("multi")
+            .help("Use multiline strings")
+            .short('m')
+            .long("multiline")
+            .action(ArgAction::SetTrue)
+        )
         .arg(
             Arg::new("debug")
                 .help("turn on debugging information")
@@ -70,6 +76,7 @@ usage:
     let filename = matches.get_one::<String>("input").unwrap();
     let backup = matches.get_flag("backup");
     let _inplace = matches.get_flag("inplace");
+    let multiline = matches.get_flag("multi");
     let debug = matches.get_flag("debug");
 
     let id = Ulid::new().to_string();
@@ -106,6 +113,9 @@ usage:
         let mut content = String::new();
         {
             let mut emitter = YamlEmitter::new(&mut content);
+            if multiline {
+                emitter.multiline_strings(true);
+            }
             emitter.dump(doc).unwrap(); // dump the YAML object to a String
         }
         content.push('\n');

--- a/testdata/bar.yaml
+++ b/testdata/bar.yaml
@@ -1,0 +1,5 @@
+---
+foo:
+  - bar: |
+      echo 1
+      echo 2

--- a/testdata/foo.yaml
+++ b/testdata/foo.yaml
@@ -1,0 +1,3 @@
+---
+foo:
+  - bar: "echo 1\necho 2\n"

--- a/testdata/functest.sh
+++ b/testdata/functest.sh
@@ -8,6 +8,8 @@ mkdir -p tests
 cp -v ./testdata/bad.yaml ./tests/bad.yaml
 cp -v ./testdata/bad.yaml ./tests/inplace.yaml
 cp -v ./testdata/bad.yaml ./tests/inplace_w_bak.yaml
+cp -v ./testdata/foo.yaml ./tests/foo.yaml
+cp -v ./testdata/bar.yaml ./tests/bar.yaml
 
 echo "test stdout"
 ./target/debug/ymlfxr ./tests/bad.yaml > ./tests/good.yaml
@@ -20,4 +22,7 @@ echo "test --bak --fix"
 yamllint -s ./tests/inplace_w_bak.yaml || exit 1
 echo "testing the backup file expect errors" 
 yamllint -s ./tests/inplace_w_bak.yaml.bak && exit 1
+echo "testing multiline support"
+./target/debug/ymlfxr -m ./tests/foo.yaml > ./tests/multi.yaml
+diff -u ./tests/bar.yaml ./tests/multi.yaml || exit 1
 rm -rfv ./tests


### PR DESCRIPTION
## Summary by Sourcery

Add multiline string support to the YAML formatter CLI tool

New Features:
- Add new --multiline (-m) option to support multiline string formatting

Enhancements:
- Improve CLI usage documentation
- Update command-line argument parsing

Tests:
- Add functional tests for multiline string support